### PR TITLE
Writefile action example error

### DIFF
--- a/docs/creating-manifest/actions.md
+++ b/docs/creating-manifest/actions.md
@@ -609,6 +609,8 @@ writeFile:
   nodeId: number or string
   nodeGroup: string
   nodeType: string
+  path: string
+  body: string
 ```
 ``` json
 {


### PR DESCRIPTION
Writefile action YAML example two parameters missed
  path: string
  body: string