### PR TITLE
Supp stacks url replaced in actions.md

### DIFF
--- a/docs/creating-manifest/actions.md
+++ b/docs/creating-manifest/actions.md
@@ -753,7 +753,7 @@ addNodes:
 @@!
 where:
 
-- `nodeType` *[required]* - parameter to specify <a href="/1.6/creating-manifest/selecting-containers/#predefined-nodetype-values" target="_blank">software stacks</a>. For Docker containers the *nodeType* value is **docker**.                                        
+- `nodeType` *[required]* - parameter to specify <a href="/creating-manifest/selecting-containers/#supported-stacks" target="_blank">software stacks</a>. For Docker containers the *nodeType* value is **docker**.                                        
 - `extip` *[optional]* - attaching the external IP address to a container. The default value is *'false'*.                     
 - `fixedCloudlets` *[optional]* - number of reserved cloudlets. The default value is *'0'*.                             
 - `flexibleCloudlets` *[optional]* - number of dynamic cloudlets. The default value is *'1'*.                           

--- a/docs/creating-manifest/actions.md
+++ b/docs/creating-manifest/actions.md
@@ -753,7 +753,7 @@ addNodes:
 @@!
 where:
 
-- `nodeType` *[required]* - parameter to specify <a href="/creating-manifest/selecting-containers/#supported-stacks" target="_blank">software stacks</a>. For Docker containers the *nodeType* value is **docker**.                                        
+- `nodeType` *[required]* - parameter to specify <a href="creating-manifest/selecting-containers/#supported-stacks" target="_blank">software stacks</a>. For Docker containers the *nodeType* value is **docker**.                                        
 - `extip` *[optional]* - attaching the external IP address to a container. The default value is *'false'*.                     
 - `fixedCloudlets` *[optional]* - number of reserved cloudlets. The default value is *'0'*.                             
 - `flexibleCloudlets` *[optional]* - number of dynamic cloudlets. The default value is *'1'*.                           


### PR DESCRIPTION
Hardcoded URL for supported stacks replaced with  https://docs.cloudscripting.com/creating-manifest/selecting-containers/#supported-stacks 